### PR TITLE
Fix re-execution of cupAndlex Mojos during incremental builds

### DIFF
--- a/cupAndlex/src/main/java/org/qenherkhopeshef/jsesh/prepare/CupMojo.java
+++ b/cupAndlex/src/main/java/org/qenherkhopeshef/jsesh/prepare/CupMojo.java
@@ -96,8 +96,10 @@ public class CupMojo extends AbstractMojo {
 			File targetParserFile = new File(createParserDir(), parserName + ".java");
 
 			// Test the creation date
-			if (sourceFile.lastModified() < targetParserFile.lastModified())
+			if (sourceFile.lastModified() < targetParserFile.lastModified()) {
+				project.addCompileSourceRoot(getJavaSourcePath().getPath());
 				return;
+			}
 
 			java_cup.Main.main(args);
 			if (targetParserFile.exists()) {

--- a/cupAndlex/src/main/java/org/qenherkhopeshef/jsesh/prepare/LexMojo.java
+++ b/cupAndlex/src/main/java/org/qenherkhopeshef/jsesh/prepare/LexMojo.java
@@ -75,8 +75,10 @@ public class LexMojo extends AbstractMojo {
 			File finalResultFile = new File(createPackage(lexerPackage), finalResultName);
 
 			// Avoid unnecessary processing
-			if (finalResultFile.lastModified() > sourceFile.lastModified())
+			if (finalResultFile.lastModified() > sourceFile.lastModified()) {
+				project.addCompileSourceRoot(getJavaSourcePath().getAbsolutePath());
 				return;
+			}
 			JLex.Main.main(args);
 			if (finalResultFile.exists()) {
 				finalResultFile.delete();


### PR DESCRIPTION
This PR fixes an issue with the cupAndlex Mojos that was interfering with incremental builds.

Previously, CupMojo and LexMojo checked whether the output file was newer than the input file, and if it was, they'd simply bail out. But that skipped the `project.addCompileSourceRoot()` call that's needed to make those output files available to the other modules, meaning that builds would succeed the _first_ time, and then fail every time after until `mvn clean` was run.

Now, right before the early return `project.addCompileSourceRoot()` is called to ensure that the output files are available on every run.

### Before
```console
$ mvn clean
[...cleaned...]
$ mvn package
[...successful run...]
$ mvn package
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] JSesh complete distribution                                        [pom]
[INFO] cupAndlex Maven Mojo                                      [maven-plugin]
[INFO] cupruntime                                                         [jar]
[INFO] qenherkhopeshefUtils                                               [jar]
[INFO] jsesh                                                              [jar]
[INFO] prepareJSeshRelease Maven Mojo                            [maven-plugin]
[INFO] jseshGlyph                                                         [jar]
[INFO] jhotdrawfw                                                         [jar]
[INFO] jseshLabels                                                        [jar]
[INFO] jseshSearch                                                        [jar]
[INFO] jseshAppli                                                         [jar]
[INFO] signInfoAppli                                                      [jar]
[INFO] jsesh-installer                                                    [pom]
[INFO] jseshDemos                                                         [jar]
[INFO] 
[INFO] ----------------< org.qenherkhopeshef.jsesh:JSesh-all >-----------------
[INFO] Building JSesh complete distribution 7.8.0-SNAPSHOT               [1/14]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] ----------------< org.qenherkhopeshef.jsesh:cupAndlex >-----------------
[INFO] Building cupAndlex Maven Mojo 7.8.0-SNAPSHOT                      [2/14]
[INFO] ----------------------------[ maven-plugin ]----------------------------
[INFO] 
[INFO] --- maven-resources-plugin:2.5:resources (default-resources) @ cupAndlex ---
[debug] execute contextualize
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ferd/rpmbuild/REPOS/jsesh/cupAndlex/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cupAndlex ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-plugin-plugin:3.6.0:descriptor (default-descriptor) @ cupAndlex ---
[INFO] Using 'UTF-8' encoding to read mojo source files.
[INFO] java-javadoc mojo extractor found 0 mojo descriptor.
[INFO] java-annotations mojo extractor found 2 mojo descriptors.
[INFO] 
[INFO] --- maven-plugin-plugin:3.6.0:descriptor (mojo-descriptor) @ cupAndlex ---
[INFO] Using 'UTF-8' encoding to read mojo source files.
[INFO] java-javadoc mojo extractor found 0 mojo descriptor.
[INFO] java-annotations mojo extractor found 2 mojo descriptors.
[INFO] 
[INFO] --- maven-resources-plugin:2.5:testResources (default-testResources) @ cupAndlex ---
[debug] execute contextualize
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ferd/rpmbuild/REPOS/jsesh/cupAndlex/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cupAndlex ---
[INFO] No sources to compile
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cupAndlex ---
[INFO] No tests to run.
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ cupAndlex ---
[INFO] Building jar: /home/ferd/rpmbuild/REPOS/jsesh/cupAndlex/target/cupAndlex-7.8.0-SNAPSHOT.jar
[INFO] 
[INFO] --- maven-plugin-plugin:3.6.0:addPluginArtifactMetadata (default-addPluginArtifactMetadata) @ cupAndlex ---
[INFO] 
[INFO] ----------------< org.qenherkhopeshef.jsesh:cupruntime >----------------
[INFO] Building cupruntime 7.8.0-SNAPSHOT                                [3/14]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-resources-plugin:2.5:resources (default-resources) @ cupruntime ---
[debug] execute contextualize
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ferd/rpmbuild/REPOS/jsesh/cupruntime/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cupruntime ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-resources-plugin:2.5:testResources (default-testResources) @ cupruntime ---
[debug] execute contextualize
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ferd/rpmbuild/REPOS/jsesh/cupruntime/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cupruntime ---
[INFO] No sources to compile
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cupruntime ---
[INFO] No tests to run.
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ cupruntime ---
[INFO] 
[INFO] -----------< org.qenherkhopeshef.jsesh:qenherkhopeshefUtils >-----------
[INFO] Building qenherkhopeshefUtils 7.8.0-SNAPSHOT                      [4/14]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-resources-plugin:2.5:resources (default-resources) @ qenherkhopeshefUtils ---
[debug] execute contextualize
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 10 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ qenherkhopeshefUtils ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-resources-plugin:2.5:testResources (default-testResources) @ qenherkhopeshefUtils ---
[debug] execute contextualize
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ferd/rpmbuild/REPOS/jsesh/qenherkhopeshefUtils/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ qenherkhopeshefUtils ---
[INFO] No sources to compile
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ qenherkhopeshefUtils ---
[INFO] No tests to run.
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ qenherkhopeshefUtils ---
[INFO] 
[INFO] ------------------< org.qenherkhopeshef.jsesh:jsesh >-------------------
[INFO] Building jsesh 7.8.0-SNAPSHOT                                     [5/14]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- cupAndlex:7.8.0-SNAPSHOT:cup (1) @ jsesh ---
[INFO] 
[INFO] --- cupAndlex:7.8.0-SNAPSHOT:lex (1) @ jsesh ---
[INFO] 
[INFO] --- maven-resources-plugin:2.5:resources (default-resources) @ jsesh ---
[debug] execute contextualize
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 165 resources
[INFO] Copying 3 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ jsesh ---
[INFO] Changes detected - recompiling the module! :input tree
[INFO] Compiling 439 source files with javac [debug release 11] to target/classes
[INFO] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/editor/JMDCEditorWorkflow.java: Some input files use or override a deprecated API.
[INFO] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/editor/JMDCEditorWorkflow.java: Recompile with -Xlint:deprecation for details.
[INFO] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/utils/TclImporter.java: Some input files use unchecked or unsafe operations.
[INFO] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/utils/TclImporter.java: Recompile with -Xlint:unchecked for details.
[INFO] -------------------------------------------------------------
[WARNING] COMPILATION WARNING : 
[INFO] -------------------------------------------------------------
[WARNING] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdcDisplayer/preferences/DrawingPreferences.java:[272,11] deprecated item is not annotated with @Deprecated
[INFO] 1 warning
[INFO] -------------------------------------------------------------
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/MDCParserFacade.java:[8,24] package jsesh.mdc.parser does not exist
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/MDCParserFacade.java:[25,17] cannot find symbol
  symbol:   class MDCParse
  location: class jsesh.mdc.MDCParserFacade
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCHRule.java:[5,34] cannot find symbol
  symbol: class MDCSymbols
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCLex.java:[32,17] cannot find symbol
  symbol:   class MDCLexAux
  location: class jsesh.mdc.lex.MDCLex
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCCartouche.java:[9,38] cannot find symbol
  symbol: class MDCSymbols
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCStartOldCartouche.java:[7,46] cannot find symbol
  symbol: class MDCSymbols
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCShading.java:[3,36] cannot find symbol
  symbol: class MDCSymbols
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/MDCParserFacade.java:[36,30] cannot find symbol
  symbol:   class MDCParse
  location: class jsesh.mdc.MDCParserFacade
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCLex.java:[43,37] cannot find symbol
  symbol:   class MDCLexAux
  location: class jsesh.mdc.lex.MDCLex
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCLex.java:[51,37] cannot find symbol
  symbol:   class MDCLexAux
  location: class jsesh.mdc.lex.MDCLex
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCLex.java:[57,56] cannot find symbol
  symbol:   variable MDCSymbols
  location: class jsesh.mdc.lex.MDCLex
[INFO] 11 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for JSesh complete distribution 7.8.0-SNAPSHOT:
[INFO] 
[INFO] JSesh complete distribution ........................ SUCCESS [  0.003 s]
[INFO] cupAndlex Maven Mojo ............................... SUCCESS [  3.665 s]
[INFO] cupruntime ......................................... SUCCESS [  0.024 s]
[INFO] qenherkhopeshefUtils ............................... SUCCESS [  0.100 s]
[INFO] jsesh .............................................. FAILURE [  4.502 s]
[INFO] prepareJSeshRelease Maven Mojo ..................... SKIPPED
[INFO] jseshGlyph ......................................... SKIPPED
[INFO] jhotdrawfw ......................................... SKIPPED
[INFO] jseshLabels ........................................ SKIPPED
[INFO] jseshSearch ........................................ SKIPPED
[INFO] jseshAppli ......................................... SKIPPED
[INFO] signInfoAppli ...................................... SKIPPED
[INFO] jsesh-installer .................................... SKIPPED
[INFO] jseshDemos ......................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.529 s
[INFO] Finished at: 2023-04-30T20:07:47-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project jsesh: Compilation failure: Compilation failure: 
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/MDCParserFacade.java:[8,24] package jsesh.mdc.parser does not exist
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/MDCParserFacade.java:[25,17] cannot find symbol
[ERROR]   symbol:   class MDCParse
[ERROR]   location: class jsesh.mdc.MDCParserFacade
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCHRule.java:[5,34] cannot find symbol
[ERROR]   symbol: class MDCSymbols
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCLex.java:[32,17] cannot find symbol
[ERROR]   symbol:   class MDCLexAux
[ERROR]   location: class jsesh.mdc.lex.MDCLex
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCCartouche.java:[9,38] cannot find symbol
[ERROR]   symbol: class MDCSymbols
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCStartOldCartouche.java:[7,46] cannot find symbol
[ERROR]   symbol: class MDCSymbols
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCShading.java:[3,36] cannot find symbol
[ERROR]   symbol: class MDCSymbols
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/MDCParserFacade.java:[36,30] cannot find symbol
[ERROR]   symbol:   class MDCParse
[ERROR]   location: class jsesh.mdc.MDCParserFacade
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCLex.java:[43,37] cannot find symbol
[ERROR]   symbol:   class MDCLexAux
[ERROR]   location: class jsesh.mdc.lex.MDCLex
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCLex.java:[51,37] cannot find symbol
[ERROR]   symbol:   class MDCLexAux
[ERROR]   location: class jsesh.mdc.lex.MDCLex
[ERROR] /home/ferd/rpmbuild/REPOS/jsesh/jsesh/src/main/java/jsesh/mdc/lex/MDCLex.java:[57,56] cannot find symbol
[ERROR]   symbol:   variable MDCSymbols
[ERROR]   location: class jsesh.mdc.lex.MDCLex
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :jsesh
$ mvn clean
[...cleaned...]
$ mvn package
[...successful run...]
```

### After
```console
$ mvn clean
[...cleaned...]
$ mvn package
[...successful run...]
$ mvn package
[...successful re-run...]
```